### PR TITLE
refact(jdbc): using jdbc-url instead db-specs

### DIFF
--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,1 +1,5 @@
-{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}
+{:hooks
+ {:analyze-call
+  {taoensso.encore/defalias    taoensso.encore/defalias
+   taoensso.encore/defn-cached taoensso.encore/defn-cached
+   taoensso.encore/defonce     taoensso.encore/defonce}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,16 +1,51 @@
 (ns taoensso.encore
+  "I don't personally use clj-kondo, so these hooks are
+  kindly authored and maintained by contributors.
+  PRs very welcome! - Peter Taoussanis"
+  (:refer-clojure :exclude [defonce])
   (:require
    [clj-kondo.hooks-api :as hooks]))
 
-(defn defalias [{:keys [node]}]
+(defn defalias
+  [{:keys [node]}]
   (let [[sym-raw src-raw] (rest (:children node))
-        src (if src-raw src-raw sym-raw)
-        sym (if src-raw
-              sym-raw
-              (symbol (name (hooks/sexpr src))))]
-    {:node (with-meta
-             (hooks/list-node
-               [(hooks/token-node 'def)
-                (hooks/token-node (hooks/sexpr sym))
-                (hooks/token-node (hooks/sexpr src))])
-             (meta src))}))
+        src (or src-raw sym-raw)
+        sym (if src-raw sym-raw (symbol (name (hooks/sexpr src))))]
+    {:node
+     (with-meta
+       (hooks/list-node
+         [(hooks/token-node 'def)
+          (hooks/token-node (hooks/sexpr sym))
+          (hooks/token-node (hooks/sexpr src))])
+       (meta src))}))
+
+(defn defn-cached
+  [{:keys [node]}]
+  (let [[sym _opts binding-vec & body] (rest (:children node))]
+    {:node
+     (hooks/list-node
+       (list
+         (hooks/token-node 'def)
+         sym
+         (hooks/list-node
+           (list*
+             (hooks/token-node 'fn)
+             binding-vec
+             body))))}))
+
+(defn defonce
+  [{:keys [node]}]
+  ;; args = [sym doc-string? attr-map? init-expr]
+  (let [[sym & args] (rest (:children node))
+        [doc-string args]    (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next  args)] [nil        args])
+        [attr-map init-expr] (if (and (hooks/map-node?    (first args)) (next args)) [(hooks/sexpr (first args)) (fnext args)] [nil (first args)])
+
+        attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
+        sym+meta (if attr-map (with-meta sym attr-map) sym)
+        rewritten
+        (hooks/list-node
+          [(hooks/token-node 'clojure.core/defonce)
+           sym+meta
+           init-expr])]
+
+    {:node rewritten}))

--- a/src/parenthesin/components/db/jdbc_hikari.clj
+++ b/src/parenthesin/components/db/jdbc_hikari.clj
@@ -13,11 +13,14 @@
 (defrecord Database [config ^HikariDataSource datasource]
   component/Lifecycle
   (start [this]
-    (let [{:keys [host port dbtype] :as db-spec} (get-in config [:config :database])]
-      (logs/log :info :database :start {:host host :port port :dbtype dbtype})
+    (let [db-spec (get-in config [:config :database])
+          jdbc-url (connection/jdbc-url (dissoc db-spec :username :password))
+          db-auth (select-keys db-spec [:username :password])]
+      (logs/log :info :database :start jdbc-url)
       (if datasource
         this
-        (assoc this :datasource (connection/->pool HikariDataSource db-spec)))))
+        (assoc this :datasource (connection/->pool HikariDataSource (assoc db-auth :jdbcUrl jdbc-url))))))
+
   (stop [this]
     (logs/log :info :database :stop)
     (if datasource

--- a/src/parenthesin/helpers/migrations.clj
+++ b/src/parenthesin/helpers/migrations.clj
@@ -1,6 +1,7 @@
 (ns parenthesin.helpers.migrations
   (:require [migratus.core :as migratus]
             [next.jdbc :as jdbc]
+            [next.jdbc.connection :as connection]
             [parenthesin.components.config.aero :as config.aero])
   (:gen-class))
 
@@ -8,8 +9,9 @@
   ([]
    (get-connection {}))
   ([input-map]
-   (let [{:keys [username] :as db} (-> (config.aero/read-config input-map) :database)]
-     (jdbc/get-connection (assoc db :user username)))))
+   (let [{:keys [username] :as db-spec} (-> (config.aero/read-config input-map) :database)
+         jdbc-url (connection/jdbc-url (assoc db-spec :user username))]
+     (jdbc/get-connection {:jdbcUrl jdbc-url}))))
 
 (def configuration
   {:store         :database


### PR DESCRIPTION
From [next-jdbc docs](https://github.com/seancorfield/next-jdbc/blob/develop/doc/getting-started.md#connection-pooling):

If you need to pass in extra connection URL parameters, it can be easier to use next.jdbc.connection/jdbc-url to construct URL, e.g.,
```clojure
(connection/->pool com.zaxxer.hikari.HikariDataSource
                   {:jdbcUrl
                    (connection/jdbc-url {:dbtype "mysql" :dbname "thedb" :useSSL false})
                    :username "dbuser" :password "secret"})
```
Here we pass :useSSL false to jdbc-url so that it ends up in the connection string, but pass :username and :password for the pool itself.